### PR TITLE
Fix redirect to upload page bug

### DIFF
--- a/app/views/v2/procurement-operations/approach-to-market/complete-information-gathering.html
+++ b/app/views/v2/procurement-operations/approach-to-market/complete-information-gathering.html
@@ -110,7 +110,7 @@
               </fieldset>
             </div>
             <div class="govuk-button-group">
-              <button type="submit" class="govuk-button" data-module="govuk-button">
+              <button type="submit" class="govuk-button" data-module="govuk-button" name="pageAction" value="continue">
                 Continue
               </button>
               <a class="govuk-link" href="../procurement">Cancel</a>

--- a/app/views/v2/school-buyer/approach-to-market/complete-information-gathering.html
+++ b/app/views/v2/school-buyer/approach-to-market/complete-information-gathering.html
@@ -68,7 +68,7 @@
               </button>
             </div>
             <div class="govuk-button-group">
-              <button type="submit" class="govuk-button" data-module="govuk-button">
+              <button type="submit" class="govuk-button" data-module="govuk-button" name="pageAction" value="continue">
                 Continue
               </button>
               <a class="govuk-link" href="../procurement">Cancel</a>


### PR DESCRIPTION
After uploading, because the variable was set to
upload then it would redirect to the upload page
even when the user clicked the continue button.

By setting a value for pageAction on the continue
buttons this behaviour bug is guarded against.