### PR TITLE
29 1 25 design crit

### DIFF
--- a/app/views/layouts/govuk-notify.html
+++ b/app/views/layouts/govuk-notify.html
@@ -25,14 +25,6 @@
           <a href="/" class="dfe-header__link--service">Get help buying for schools</a>
       </div>
     </header>
-    <div class="govuk-phase-banner govuk-width-container">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
-        <span class="govuk-phase-banner__text">This is a new service. Help us
-          improve it and <a class="govuk-link" href="https://staging.get-help-buying-for-schools.service.gov.uk/customer_satisfaction_surveys/new?service=supported_journey&source=banner_link">
-          give your feedback by email</a>.</span>
-      </p>
-    </div>
   {% endblock %}
   {% block scripts %}
     {{ super() }}

--- a/app/views/v4/emails/school-buyer/invite-to-portal.html
+++ b/app/views/v4/emails/school-buyer/invite-to-portal.html
@@ -19,9 +19,6 @@
       <p class="govuk-body govuk-!-margin-top-9">[Case worker full name]</p>
       <p class="govuk-body">Procurement Specialist</p>
       <p class="govuk-body">Get help buying for schools</p>
-      <p class="govuk-body govuk-!-padding-bottom-6">We'll close the case if
-        we don't hear back from you. You can reopen the case at any time by
-        replying to this email.</p>
       <p class="govuk-body govuk-!-margin-top-9">Get help buying for schools
         service disclaimer</p>
       <p class="govuk-body">Please note that the expertise and advice being

--- a/app/views/v4/emails/school-buyer/invite-to-portal.html
+++ b/app/views/v4/emails/school-buyer/invite-to-portal.html
@@ -19,8 +19,6 @@
       <p class="govuk-body govuk-!-margin-top-9">[Case worker full name]</p>
       <p class="govuk-body">Procurement Specialist</p>
       <p class="govuk-body">Get help buying for schools</p>
-      <p class="govuk-body">Reply to this email within 15 working days or by
-        the date agreed. Late replies can delay the procurement process.</p>
       <p class="govuk-body govuk-!-padding-bottom-6">We'll close the case if
         we don't hear back from you. You can reopen the case at any time by
         replying to this email.</p>

--- a/app/views/v4/emails/school-buyer/invite-to-portal.html
+++ b/app/views/v4/emails/school-buyer/invite-to-portal.html
@@ -10,10 +10,10 @@
         process for [Sub-category] procurement for [Organisation name].</p>
       <p class="govuk-body govuk-!-font-weight-bold">Sign in to view tasks</p>
       <p class="govuk-body">Click this <a href="../../school-buyer/start" class="govuk-link" rel="noreferrer noopener" target="_blank">
-        unique case-specific link</a> to access your procurement
-        task list. You will need to sign in with your DfE Sign-in account.
-        If you do not have a DfE Sign-in account, you will need to create
-        one.</p>
+        unique case-specific link (opens in new tab)</a> to access
+        your procurement task list. You will need to sign in with your DfE
+        Sign-in account. If you do not have a DfE Sign-in account, you will need
+        to create one.</p>
       <p class="govuk-body">From here you will be able to see all the tasks
         you will need to complete.</p>
       <p class="govuk-body govuk-!-margin-top-9">[Case worker full name]</p>

--- a/app/views/v4/includes/key-procurement-info.html
+++ b/app/views/v4/includes/key-procurement-info.html
@@ -7,7 +7,7 @@
     Marissa Dale</p>
   <p class="govuk-body govuk-!-margin-0">
     <span class="govuk-!-font-weight-bold">Organisation:</span>
-    Bueller Trust</p>
+    United Learning</p>
   <p class="govuk-body govuk-!-margin-0">
     <span class="govuk-!-font-weight-bold">Target end date:</span>
     25 July 2026</p>


### PR DESCRIPTION
- phase banner removed from email
- email link now states it will open in new tab
- remove 15 days warning from invite email
- remove sentence about closing procurement if we do not hear back from them
- the procurement now uses United Learning as the one trust identifier. Previously, it had United Learning and the Bueller Trust.