### PR TITLE
Fix typos in ver 7

### DIFF
--- a/app/routes/v7/procurement-operations/prepare-and-go-to-market.js
+++ b/app/routes/v7/procurement-operations/prepare-and-go-to-market.js
@@ -146,7 +146,7 @@ module.exports = function (router) {
     const tagSignOffBidDocumentWithSchool = req.session.data['tagSignOffBidDocumentWithSchool']
 
     if (tagSignOffBidDocumentWithSchool.includes('Email pack to the school') &&
-        tagSignOffBidDocumentWithSchool.includes('Approval from school recieved') &&
+        tagSignOffBidDocumentWithSchool.includes('Approval from school received') &&
         tagSignOffBidDocumentWithSchool.includes('Save approval screenshot in SharePoint') &&
         tagSignOffBidDocumentWithSchool.includes('empty')){
       req.session.data.tagSignOffBidDocumentWithSchoolStatus = 'complete'

--- a/app/views/v7/procurement-operations/prepare-and-go-to-market/get-g7-approval.html
+++ b/app/views/v7/procurement-operations/prepare-and-go-to-market/get-g7-approval.html
@@ -42,14 +42,14 @@
                 <p class="govuk-body">The G7 who will give approval will usually
                   be your line manager. They will check:</p>
                   <ul class="govuk-list govuk-list--bullet">
-                    <li>All documents are included in the pack/li>
+                    <li>All documents are included in the pack</li>
                     <li>The name of the school is correct in all places</li>
                     <li>The calculations in the spreadsheets are correct</li>
                     <li>The evaluation methodology is compliant with existing legislation</li>
                   </ul>
                 </div>
-              </div>
-            </details>
+              </details>
+            </div>
           </div>
             <div class="govuk-form-group">
               <h2 class="govuk-heading-m">Actions</h2>

--- a/app/views/v7/procurement-operations/prepare-and-go-to-market/refine-specification-with-school.html
+++ b/app/views/v7/procurement-operations/prepare-and-go-to-market/refine-specification-with-school.html
@@ -35,9 +35,9 @@
                 and check for any legislation which could affect the procurement
                 to ensure compliance.</p>
               <p class="govuk-body">Remove any unnecessary sections and complete
-                the specification based on the information the school has already
-                already provided.The specification can then be refined following
-                a meeting with the school.</p>
+                the specification based on the information the school has
+                already provided. The specification can then be refined
+                following a meeting with the school.</p>
               <p class="govuk-body">A specification is required for each school
                 involved in the procurement.</p>
               <details class="govuk-details" data-module="govuk-details">

--- a/app/views/v7/procurement-operations/prepare-and-go-to-market/sign-off-bid-document-with-school.html
+++ b/app/views/v7/procurement-operations/prepare-and-go-to-market/sign-off-bid-document-with-school.html
@@ -30,9 +30,11 @@
         <div class="govuk-grid-column-two-thirds">
           <form action="sign-off-bid-document-with-school" method="post" novalidate>
             <div class="govuk-form-group">
-              <p class="govuk-body">Send document pack to the school for approval.</p>
-              <p class="govuk-body">You should emphasise to the school lead the legal
-                importance of carefully checking and approving the document pack.</p>
+              <p class="govuk-body">Send document pack to the school for
+                approval.</p>
+              <p class="govuk-body">You should emphasise to the school lead the
+                legal importance of carefully checking and approving the
+                document pack.</p>
             </div>
             <div class="govuk-form-group">
               <h2 class="govuk-heading-m">Actions</h2>
@@ -45,9 +47,9 @@
                     </label>
                   </div>
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="tagSignOffBidDocumentWithSchool-2" name="tagSignOffBidDocumentWithSchool" type="checkbox" value="Approval from school recieved" {{ checked("tagSignOffBidDocumentWithSchool", "Approval from school recieved") }}>
+                    <input class="govuk-checkboxes__input" id="tagSignOffBidDocumentWithSchool-2" name="tagSignOffBidDocumentWithSchool" type="checkbox" value="Approval from school received" {{ checked("tagSignOffBidDocumentWithSchool", "Approval from school received") }}>
                     <label class="govuk-label govuk-checkboxes__label" for="tagSignOffBidDocumentWithSchool-2">
-                      Approval from school recieved
+                      Approval from school received
                     </label>
                   </div>
                   <div class="govuk-checkboxes__item">


### PR DESCRIPTION
- FIX add missing full stop spacing on guidance text
- FIX badly formed details component (divs and ordering)
- FIX typo- approval from school received now correctly spelt and routing updated