### PR TITLE
Add in CMS start page with sign out notification

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -4,14 +4,19 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">Get help buying for schools</h1>
       <h2 class="govuk-heading-m">V10 Updating branding</h2>
-      <p><a class="govuk-link" href="v10/procurement?branding=DfE&userType=procurement-operations&navSelected=My%20cases">Procurement operations</a> |
+      <p class="govuk-body govuk-!-width-full" style="max-width: 100%;"><a class="govuk-link" href="v10/procurement?branding=DfE&userType=procurement-operations&navSelected=My%20cases">Procurement operations</a> |
         <a class="govuk-link" href="v10/sign-in?branding=DfE&userType=school-buyer&navSelected=My%20cases">School buyer portal</a> |
         <a class="govuk-link" href="v10/emails/school-buyer/invite-to-portal?branding=DfE&userType=school-buyer&navSelected=My%20cases">School buyer email</a> |
-        <a class="govuk-link" href="v10/artefacts/evaluator-login?branding=DfE&userType=school-buyer&navSelected=My%20cases">Evaluator login</a></p>
+        <a class="govuk-link" href="v10/artefacts/evaluator-login?branding=DfE&userType=school-buyer&navSelected=My%20cases">Evaluator login</a> |
+        <a class="govuk-link" href="v10/artefacts/cms-login?userType=procurement-operations&navSelected=My%20cases&signOut=true">CMS login</a></p>
         <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://dfedigital.atlassian.net/browse/ES-698" class="govuk-link">
+            CMS start page (opens in new tab)</a>
+            - creating a start page for CMS users so they do not have to use the
+            create a spec start page</li>
           <li><a href="https://dfedigital.atlassian.net/browse/ES-681" class="govuk-link">
             Update branding (opens in new tab)</a>
             in prototype and increment to v10</li>

--- a/app/views/layouts/main-branding-2025.html
+++ b/app/views/layouts/main-branding-2025.html
@@ -24,67 +24,68 @@
                 {{serviceName}}
             </a>
             </span>
-            <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
-                <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden="">
-                Menu
-            </button>
-                <ul class="govuk-service-navigation__list" id="navigation">
-                    {% if (data['navSelected'] == 'My cases') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="/v10/procurement?navSelected=My cases">
-                        My cases
-                      </a>
-                    </li>
-                    {% if (data['navSelected'] == 'Notifications') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="?navSelected=Notifications">
-                        Notifications
-                      </a>
-                    </li>
-                    {% if (data['navSelected'] == 'Find a case') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="?navSelected=Find a case">
-                        Find a case
-                      </a>
-                    </li>
-                    {% if (data['navSelected'] == 'Case statistics') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="?navSelected=Case statistics">
-                        Case statistics
-                      </a>
-                    </li>
-                    {% if (data['navSelected'] == 'Frameworks') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="?navSelected=Frameworks">
-                        Frameworks
-                      </a>
-                    </li>
-                    {% if (data['navSelected'] == 'Management') %}
-                      <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                    {% else %}
-                      <li class="govuk-service-navigation__item">
-                    {% endif %}
-                      <a class="govuk-service-navigation__link" href="?navSelected=Management">
-                        Management
-                      </a>
-                    </li>
-                </ul>
-            </nav>
+            {% if (data['hideNavigation'] != 'true') %}
+              <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
+                  <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden="">
+                    Menu</button>
+                  <ul class="govuk-service-navigation__list" id="navigation">
+                      {% if (data['navSelected'] == 'My cases') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="/v10/procurement?navSelected=My cases">
+                          My cases
+                        </a>
+                      </li>
+                      {% if (data['navSelected'] == 'Notifications') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="?navSelected=Notifications">
+                          Notifications
+                        </a>
+                      </li>
+                      {% if (data['navSelected'] == 'Find a case') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="?navSelected=Find a case">
+                          Find a case
+                        </a>
+                      </li>
+                      {% if (data['navSelected'] == 'Case statistics') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="?navSelected=Case statistics">
+                          Case statistics
+                        </a>
+                      </li>
+                      {% if (data['navSelected'] == 'Frameworks') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="?navSelected=Frameworks">
+                          Frameworks
+                        </a>
+                      </li>
+                      {% if (data['navSelected'] == 'Management') %}
+                        <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                      {% else %}
+                        <li class="govuk-service-navigation__item">
+                      {% endif %}
+                        <a class="govuk-service-navigation__link" href="?navSelected=Management">
+                          Management
+                        </a>
+                      </li>
+                  </ul>
+              </nav>
+            {% endif %}
         </div>
     </div>
   </section>

--- a/app/views/v10/artefacts/cms-login.html
+++ b/app/views/v10/artefacts/cms-login.html
@@ -1,0 +1,47 @@
+{% extends "layouts/main-branding-2025.html" %}
+
+{% set pageName="Complete procurement evaluation" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if (data['signOut'] === 'true' ) %}
+        <div class="govuk-form-group">
+          <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <p class="govuk-notification-banner__heading">
+                You have signed out
+              </p>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+      <div class="govuk-form-group">
+        <h1 class="govuk-heading-xl">Case management system</h1>
+        <p class="govuk-body">Use this service to support complex school
+          procurements or onboard schools to specific schemes. You will be able to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>view support requests</li>
+          <li>email schools with guidance and procurement advice</li>
+          <li>update cases as they progress</li>
+          <li>share evaluation files and contracts with school users</li>
+        </ul>
+        <p class="govuk-body">Contact you line manager if you do not have
+          access.</p>
+      </div>
+      <div class="govuk-form-group">
+        <a href="?signOut=false" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+          Start now
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
A quick page to allow CMS and CEC users to bookmark so that they can easily sign in and out of the CMS. When signing out they hit the sign in page but
have a notification banner to say they have signed out.